### PR TITLE
Louder credentials warning and tidy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'rspec'
-gem 'rubocop', '0.72.0'
-gem 'simplecov', require: false, group: :test
-gem 'simplecov-console', require: false, group: :test
+group :test do
+  gem 'rspec'
+  gem 'rubocop', '0.72.0'
+  gem 'simplecov', require: false, group: :test
+  gem 'simplecov-console', require: false, group: :test
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'capybara'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop', '0.71.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'rspec'
-gem 'rubocop', '0.71.0'
+gem 'rubocop', '0.72.0'
 gem 'simplecov', require: false, group: :test
 gem 'simplecov-console', require: false, group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'rake'
 gem 'rspec'
 gem 'rubocop', '0.71.0'
 gem 'simplecov', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ GEM
     parser (2.6.5.0)
       ast (~> 2.4.0)
     rainbow (3.0.0)
-    rake (13.0.1)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -50,7 +49,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake
   rspec
   rubocop (= 0.71.0)
   simplecov

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GEM
     docile (1.3.2)
     jaro_winkler (1.5.4)
     json (2.2.0)
-    parallel (1.18.0)
-    parser (2.6.5.0)
+    parallel (1.19.1)
+    parser (2.7.0.2)
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rspec (3.9.0)
@@ -24,7 +24,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.71.0)
+    rubocop (0.72.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
@@ -50,7 +50,7 @@ PLATFORMS
 
 DEPENDENCIES
   rspec
-  rubocop (= 0.71.0)
+  rubocop (= 0.72.0)
   simplecov
   simplecov-console
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ GEM
     diff-lcs (1.3)
     docile (1.3.2)
     jaro_winkler (1.5.4)
-    json (2.2.0)
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
@@ -15,15 +14,15 @@ GEM
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.0)
-      rspec-support (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
     rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-support (3.9.0)
+    rspec-support (3.9.2)
     rubocop (0.72.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -32,18 +31,17 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    simplecov (0.17.1)
+    simplecov (0.18.0)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
+      simplecov-html (~> 0.11.0)
     simplecov-console (0.6.0)
       ansi
       simplecov
       terminal-table
-    simplecov-html (0.10.2)
+    simplecov-html (0.11.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
 
 PLATFORMS
   ruby
@@ -55,4 +53,4 @@ DEPENDENCIES
   simplecov-console
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,36 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
     ast (2.4.0)
-    capybara (3.29.0)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (~> 1.5)
-      xpath (~> 3.2)
     diff-lcs (1.3)
     docile (1.3.2)
     jaro_winkler (1.5.4)
     json (2.2.0)
-    mini_mime (1.0.2)
-    mini_portile2 (2.4.0)
-    nokogiri (1.10.5)
-      mini_portile2 (~> 2.4.0)
     parallel (1.18.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
-    public_suffix (4.0.1)
-    rack (2.0.7)
-    rack-test (1.1.0)
-      rack (>= 1.0, < 3)
     rainbow (3.0.0)
     rake (13.0.1)
-    regexp_parser (1.6.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -64,14 +45,11 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.6.0)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  capybara
   rake
   rspec
   rubocop (= 0.71.0)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ I would like to receive a text such as "Thank you! Your order was placed and wil
 
 * A free account on Twilio will only allow you to send texts to "verified" numbers. Use your mobile phone number, don't worry about the customer's mobile phone.
 
-* **WARNING** think twice before you push your mobile number or any private details to a public space like Github. Now is a great time to think about security and how you can keep your private information secret. You might want to explore environment variables.
+> :warning: **WARNING:** think twice before you push your **mobile number** or **Twilio API Key** to a public space like GitHub :eyes:
+>
+> :key: Now is a great time to think about security and how you can keep your private information secret. You might want to explore environment variables.
 
 * Finally submit a pull request before Monday at 9am with your solution or partial solution.  However much or little amount of code you wrote please please please submit a pull request before Monday at 9am
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,0 @@
-require 'rspec/core/rake_task'
-
-RSpec::Core::RakeTask.new :spec
-
-task default: [:spec]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'capybara/rspec'
 require 'simplecov'
 require 'simplecov-console'
 


### PR DESCRIPTION
## Why

Let's make the warning about pushing your mobile number and Twilio API Key in the README louder, so that fewer credentials will be leaked.

Capybara is not needed for this challenge, so let's remove it. Plus some other tidying.

## What

- [x] Make credentials warning louder in the README
- [x] Remove Capybara
- [x] Remove the unused Rakefile.
- [x] Bump Rubocop to 0.72.0 to remove the distracting warning about `rubocop-rails` being split into a separate gem.
- [x] Update gems in the bundle.
- [x] Group the test gems in the `Gemfile`.